### PR TITLE
勤務表は一月ごとの表示にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'pry-rails'
 gem 'devise'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -237,6 +238,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -273,6 +276,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)
   web-console (>= 3.3.0)
+  whenever
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -2,8 +2,25 @@ class AttendancesController < ApplicationController
   require "date"
   def index
     #当月のレコードを検索
-    today = Date.today
-    @attendance_list = Attendance.where(year:today.year,month:today.month)
+    if params[:search] == "次月" then
+      # if params[:month] == 12 then
+      #   @year = params[:year] + 1
+      #   nextMonth = 1
+      #   @month = nextMonth
+      # end
+      @year = params[:year]
+      @month = (params[:month].to_i) + 1
+      @attendance_list = Attendance.where(year:params[:year],month:@month)
+    elsif params[:search] == "前月" then
+      @year = params[:year]
+      @month = (params[:month].to_i) - 1
+      @attendance_list = Attendance.where(year:params[:year],month:@month)
+    else
+      today = Date.today
+      @year = today.year
+      @month = today.month
+      @attendance_list = Attendance.where(year:@year,month:@month)
+    end
   end
 
   def edit

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,12 +1,15 @@
 class AttendancesController < ApplicationController
   require "date"
   def index
-    @attendance_list = Attendance.all
+    #当月のレコードを検索
+    today = Date.today
+    @attendance_list = Attendance.where(year:today.year,month:today.month)
   end
 
   def edit
-    @today = Date.today.to_s
-    @today_attendance = Attendance.find_by(days: @today)
+    @today = Date.today
+    # @today_attendance = Attendance.find_by(days: @today)
+    @today_attendance = Attendance.find_by(year: @today.year,month:@today.month,day:@today.day)
     # 出勤・退勤時間が入力されていれば日本時間でformatを行う
     if !@today_attendance.work_start.nil? then
       @today_attendance_work_start = @today_attendance.work_start.in_time_zone('Tokyo').strftime("%H:%M")

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -3,18 +3,23 @@ class AttendancesController < ApplicationController
   def index
     #当月のレコードを検索
     if params[:search] == "次月" then
-      # if params[:month] == 12 then
-      #   @year = params[:year] + 1
-      #   nextMonth = 1
-      #   @month = nextMonth
-      # end
       @year = params[:year]
       @month = (params[:month].to_i) + 1
       @attendance_list = Attendance.where(year:params[:year],month:@month)
+      if params[:month] == "12" then
+        @year = (params[:year].to_i) + 1
+        @month = 1
+        @attendance_list = Attendance.where(year:@year,month:@month)
+      end
     elsif params[:search] == "前月" then
       @year = params[:year]
       @month = (params[:month].to_i) - 1
       @attendance_list = Attendance.where(year:params[:year],month:@month)
+      if params[:month] == "1" then 
+        @year = (params[:year].to_i) - 1
+        @month = 12
+        @attendance_list = Attendance.where(year:@year,month:@month)
+      end
     else
       today = Date.today
       @year = today.year

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,7 +1,6 @@
 class AttendancesController < ApplicationController
   require "date"
   def index
-    #当月のレコードを検索
     if params[:search] == "次月" then
       @year = params[:year]
       @month = (params[:month].to_i) + 1

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="contents">
   <div id="contents__today" class="contents__today">
-    <%= @today_attendance.days.strftime("%Y年%m月%d日") %>
+    <%= @today_attendance.year %>年<%= @today_attendance.month %>月<%= @today_attendance.day %>日
   </div>
   <%= form_with model: @today_attendance do |f| %>
     <div class="contents__btn_list">

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -16,3 +16,11 @@
     </tr>
   <% end %>
 </table>
+<%= form_tag(attendances_path,:method => 'get') do %>
+  <%= hidden_field_tag 'year', "#{@year}"%>
+  <%= hidden_field_tag 'month', "#{@month}"%>
+  <div class="btn_field" style="display:flex;justify-content:space-around;padding:30px 0 60px;">
+    <%= submit_tag '前月', name: "search", style: "width:60px;" %>
+    <%= submit_tag '次月', name: "search", style: "width:60px;" %>
+  </div>
+<% end %>

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <% @attendance_list.each do |attend| %>
     <tr class="list__contents">
-      <td><%= attend.days %></td>
+      <td><%= attend.year %>年<%= attend.month %>月<%= attend.day %>日</td>
       <td class="list__contents__performance"><input type="text" disabled="disabled" value="<%= attend.work_start %>"></td>
       <td class="list__contents__performance"><input type="text" disabled="disabled" value="<%= attend.work_start %>"></td>
       <td class="list__contents__performance"><input type="text" disabled="disabled" value="<%= attend.remarks %>"></td>

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -1,4 +1,4 @@
-<div class="title">2020年02月の勤務表</div>
+<div class="title"><%= @year %>年<%= @month %>月の勤務表</div>
 
 <table class="list">
   <tr class="list__headers">

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module HopeClogged
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,26 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+set :environment, "development"
+set :output, { :error => "log/cron_error.log" }
+set :path, "/Users/okamurayuu/projects/hope_clogged"
+every 1.month, :at => '0:00' do
+  runner 'Tasks::Attendancetask.create'
+end

--- a/db/migrate/20200308020118_add_column_to_attendance.rb
+++ b/db/migrate/20200308020118_add_column_to_attendance.rb
@@ -1,0 +1,7 @@
+class AddColumnToAttendance < ActiveRecord::Migration[5.2]
+  def change
+    add_column :attendances, :day, :integer, after: :days, null: false
+    add_column :attendances, :month, :integer, after: :days, null: false
+    add_column :attendances, :year, :integer, after: :days, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_02_212211) do
+ActiveRecord::Schema.define(version: 2020_03_08_020118) do
 
   create_table "attendances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.date "days"
+    t.integer "year", null: false
+    t.integer "month", null: false
+    t.integer "day", null: false
     t.timestamp "work_start"
     t.timestamp "work_end"
     t.text "remarks"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,9 @@ thisMonthLastDay = today.end_of_month.mday
   monthly = Date.parse(strMonthly)
   Attendance.create!(
      days: monthly,
+     year: thisYear,
+     month: thisMonth,
+     day: day,
      remarks: '腹痛のため遅刻'
    )
 end

--- a/lib/tasks/attendancetask.rb
+++ b/lib/tasks/attendancetask.rb
@@ -1,0 +1,23 @@
+require "#{Rails.root}/app/models/attendance"
+require "date"
+
+class Tasks::Attendancetask
+  def self.create
+    today = Date.today
+    thisYear = today.year
+    thisMonth = today.month
+    thisMonthLastDay = today.end_of_month.mday
+
+    (1..thisMonthLastDay).each do |day|
+      strMonthly = today.year.to_s + "/" + today.month.to_s + "/" + day.to_s
+      monthly = Date.parse(strMonthly)
+      Attendance.create(
+         days: monthly,
+         year: thisYear,
+         month: thisMonth,
+         day: day,
+         remarks: ''
+       )
+    end
+  end 
+end


### PR DESCRIPTION
# What
勤務表一覧画面を表示する際一月分を表示し、ページングのようにして、他の月も確認できるようにする

# Why
全てのデータを一覧表示すると見にくいので月ごとに分ける。
(勤務表のデータは月初にcronで定期実行し、データを作成)