### PR TITLE
ユーザー新規登録機能の変更

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,7 +20,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       thisMonthLastDay = today.end_of_month.mday
       (1..thisMonthLastDay).each do |day|
         Attendance.create(
-          user_id: current_user.id,
+          user_id: @user.id,
           year: thisYear,
           month: thisMonth,
           day: day,
@@ -33,7 +33,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       nextMonthLastDay = nextMonthDay.end_of_month.mday
       (1..nextMonthLastDay).each do |day|
         Attendance.create(
-          user_id: current_user.id,
+          user_id: @user.id,
           year: nextYear,
           month: nextMonth,
           day: day,


### PR DESCRIPTION
# what
登録失敗した時にエラー発生する現象を改善

# why
バリデーションに引っかかるとメッセージが出ないので原因が特定出来ない為